### PR TITLE
Support elapsed time in countdown options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ new CanvasCircularCountdown(element, [options], [onTimerRunning])
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | duration | <code>Number</code> | `60 * 1000` | The timer's duration in milliseconds. |
-| elapsedTime | <code>Number</code> | `0` | The time has elapsed in
+| elapsedTime | <code>Number</code> | `0` | The time that has elapsed in
 miliseconds. |
 | radius | <code>Number</code> | `150` | The radius of the circular countdown in pixels. |
 | progressBarWidth | <code>Number</code> | `15` | The circular progress bar in pixels. |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ new CanvasCircularCountdown(element, [options], [onTimerRunning])
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | duration | <code>Number</code> | `60 * 1000` | The timer's duration in milliseconds. |
+| elapsed | <code>Number</code> | `0` | The time has elapsed in
+miliseconds. |
 | radius | <code>Number</code> | `150` | The radius of the circular countdown in pixels. |
 | progressBarWidth | <code>Number</code> | `15` | The circular progress bar in pixels. |
 | progressBarOffset | <code>Number</code> | `5` | The number of pixels that will be left between the edges of the progress bar and the rest of the circle. |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ new CanvasCircularCountdown(element, [options], [onTimerRunning])
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | duration | <code>Number</code> | `60 * 1000` | The timer's duration in milliseconds. |
-| elapsed | <code>Number</code> | `0` | The time has elapsed in
+| elapsedTime | <code>Number</code> | `0` | The time has elapsed in
 miliseconds. |
 | radius | <code>Number</code> | `150` | The radius of the circular countdown in pixels. |
 | progressBarWidth | <code>Number</code> | `15` | The circular progress bar in pixels. |

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,10 @@ export default class CanvasCircularCountdown {
       throw new TypeError(`Expected a number for elapsedTime, instead got ${typeof this.options.elapsedTime}`);
     }
 
+    if (this.options.elapsedTime > this.options.duration) {
+      this.options.elapsedTime = this.options.duration;
+    }
+
     if (element.nodeName === 'CANVAS') {
       this._canvas = element;
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export default class CanvasCircularCountdown {
     const defaults = {
       duration: 60 * 1000, // ms
       radius: 150,
-      elapsed: 0,
+      elapsedTime: 0,
       progressBarWidth: 15,
       progressBarOffset: 5,
       circleBackgroundColor: '#ffffff',
@@ -31,8 +31,8 @@ export default class CanvasCircularCountdown {
       throw new TypeError(`Expected a number for duration, instead got ${typeof this.options.duration}`);
     }
 
-    if (typeof this.options.elapsed !== 'number') {
-      throw new TypeError(`Expected a number for elapsed, instead got ${typeof this.options.elapsed}`);
+    if (typeof this.options.elapsedTime !== 'number') {
+      throw new TypeError(`Expected a number for elapsedTime, instead got ${typeof this.options.elapsedTime}`);
     }
 
     if (element.nodeName === 'CANVAS') {
@@ -57,7 +57,7 @@ export default class CanvasCircularCountdown {
       && !Number.isNaN(this.options.throttle)
       && this.options.throttle <= this.options.duration;
 
-    this._timer = new Timer(this.options.duration, this.options.elapsed, shouldThrottle ? throttle(timerCallback, this.options.throttle) : timerCallback);
+    this._timer = new Timer(this.options.duration, this.options.elapsedTime, shouldThrottle ? throttle(timerCallback, this.options.throttle) : timerCallback);
 
     this._canvas.width = this.options.radius * 2;
     this._canvas.height = this.options.radius * 2;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export default class CanvasCircularCountdown {
     const defaults = {
       duration: 60 * 1000, // ms
       radius: 150,
+      elapsed: 0,
       progressBarWidth: 15,
       progressBarOffset: 5,
       circleBackgroundColor: '#ffffff',
@@ -28,6 +29,10 @@ export default class CanvasCircularCountdown {
 
     if (typeof this.options.duration !== 'number') {
       throw new TypeError(`Expected a number for duration, instead got ${typeof this.options.duration}`);
+    }
+
+    if (typeof this.options.elapsed !== 'number') {
+      throw new TypeError(`Expected a number for elapsed, instead got ${typeof this.options.elapsed}`);
     }
 
     if (element.nodeName === 'CANVAS') {
@@ -52,7 +57,7 @@ export default class CanvasCircularCountdown {
       && !Number.isNaN(this.options.throttle)
       && this.options.throttle <= this.options.duration;
 
-    this._timer = new Timer(this.options.duration, shouldThrottle ? throttle(timerCallback, this.options.throttle) : timerCallback);
+    this._timer = new Timer(this.options.duration, this.options.elapsed, shouldThrottle ? throttle(timerCallback, this.options.throttle) : timerCallback);
 
     this._canvas.width = this.options.radius * 2;
     this._canvas.height = this.options.radius * 2;

--- a/src/timer.js
+++ b/src/timer.js
@@ -23,10 +23,10 @@ class Timer {
    * @param {Number} [duration] The timer's duration (ms). If left `undefined` or `0` or negative number the timer counts up instead of down.
    * @param {Function} [callback] Function to be executed while timer is running. The Timer instance is passed by as parameter.
    */
-  constructor(duration, elapsed, callback) {
+  constructor(duration, elapsedTime, callback) {
     this._started = false;
     this._now = 0;
-    this._time = elapsed;
+    this._time = elapsedTime;
     this._duration = duration;
     this._callback = callback;
 

--- a/src/timer.js
+++ b/src/timer.js
@@ -23,10 +23,10 @@ class Timer {
    * @param {Number} [duration] The timer's duration (ms). If left `undefined` or `0` or negative number the timer counts up instead of down.
    * @param {Function} [callback] Function to be executed while timer is running. The Timer instance is passed by as parameter.
    */
-  constructor(duration, callback) {
+  constructor(duration, elapsed, callback) {
     this._started = false;
     this._now = 0;
-    this._time = 0;
+    this._time = elapsed;
     this._duration = duration;
     this._callback = callback;
 


### PR DESCRIPTION
Adding `elapsedTime` option will start the countdown at that point. For example, If the `elapsedTime ` option is set to `20_000` and the `duration` is `60_000` the countdown will have that duration but 10 seconds has elapsed which is significantly different from create a counter with only 40 seconds.

This is an example of duration `60_000` and elapsedTime `20_000`:
<img width="112" alt="Screen Shot 2022-04-19 at 16 50 40" src="https://user-images.githubusercontent.com/1541261/164107807-e1da467b-1704-4fdd-b40f-2b3a25d3efee.png">

This PR solves the following #21.