### PR TITLE
Add set function

### DIFF
--- a/src/timer.js
+++ b/src/timer.js
@@ -100,7 +100,22 @@ class Timer {
     this._time = this._elapsedTime;
     return this;
   }
-
+  
+  /**
+   * Hard sets the timer to a specified duration.
+   *
+   * @memberof Timer
+   * @this {Timer}
+   * @param {Number} [time] The time to set the timer to (ms). If it is greater than the duration, it will not do anything.
+   * @returns {Timer} The Timer instance.
+   */
+  set(time) {
+    if (time <= this._duration) {
+      this._time = time;
+    }
+    return this;
+  }
+  
   /**
    * Check (at any time) if the timer is running or not.
    *


### PR DESCRIPTION
## What this PR does
Add a function to allow hard setting the timer to a specified duration.

## Reason
The timer sometimes has to be overriden. Perhaps due to being synced with a backend server (#26 ), or due to "time bonuses" being added.
 